### PR TITLE
ありすのステージ2.6向けプライバシーポリシーを追加

### DIFF
--- a/arisute/privacy-policy-2.6.html
+++ b/arisute/privacy-policy-2.6.html
@@ -1,0 +1,75 @@
+<!DOCTYPE HTML>
+<html lang="ja">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width,maximum-scale=2.0,user-scalable=yes">
+	<meta name="robots" content="noindex">
+	<title>ありすのステージ・プライバシーポリシー 2.6</title>
+
+	<link rel="stylesheet" href="css/reset.css">
+	<link rel="stylesheet" href="css/style2.css?2017905-0105">
+	<link rel="stylesheet" href="css/arisute.css?2017905-0105">
+	<link rel="shortcut icon" href="img/favicon.ico" type="image/vnd.microsoft.ico"/>
+</head>
+
+<body class="background">
+	<article class="title-bg">
+
+		<div class="board boardtext left board-banner">
+            <div class="boardmargin">
+				<p class="space"><b>■プライバシーポリシー</b></p>
+				<div>
+					<p>
+						ありすのステージ 2.6系（以下「本アプリ」）は、利用者の個人情報を収集しません。
+					</p>
+				</div>
+				<div class="paragraph">
+					<p class="space"><b>■取得する情報について</b></p>
+					<p>
+						本アプリは、氏名、メールアドレス、位置情報、端末識別子、広告ID、連絡先、写真、その他利用者を識別できる情報を取得・収集しません。<br />
+						また、広告配信、アクセス解析、行動追跡を目的としたSDKは使用していません。
+					</p>
+
+					<p class="space"><b>■端末内に保存される情報</b></p>
+					<p>
+						本アプリは、ゲームの進行や設定を維持するため、以下の情報を利用者の端末内に保存します。
+					</p>
+					<ul>
+						<li>音量、言語、表示などの設定</li>
+						<li>スコア、ランク、クリア回数などのプレイ記録</li>
+						<li>解禁状態などのゲーム進行情報</li>
+					</ul>
+					<p>
+						これらの情報は端末内に保存され、本アプリの開発者へ送信されることはありません。
+					</p>
+
+					<p class="space"><b>■外部リンクについて</b></p>
+					<p>
+						本アプリ内には、クレジット、関連サイト、SNS、プライバシーポリシー等への外部リンクが含まれる場合があります。<br />
+						外部サイトを開いた後の情報の取り扱いについては、各サイトのプライバシーポリシーをご確認ください。
+					</p>
+
+					<p class="space"><b>■第三者への提供について</b></p>
+					<p>
+						本アプリは、利用者の個人情報を収集しないため、第三者へ提供することもありません。<br />
+						ただし、App Store、Google Play、OS、端末、外部サイト等が独自に取得する情報については、本アプリの管理対象外です。
+					</p>
+
+					<p class="space"><b>■お問い合わせ</b></p>
+					<p>Twitter <a href="https://twitter.com/fumilin">ふみ(@fumilin)</a> までDMをお願いいたします。</p>
+
+					<p class="space"><b>■改定について</b></p>
+					<p>
+						本ポリシーの内容は、必要に応じて変更される場合があります。<br />
+						変更後の内容は、本ページに掲載された時点で有効となります。
+					</p>
+
+					<p class="space">制定日: 2026年6月19日</p>
+				</div>
+			</div>
+		</div>	
+	</article>
+</body>
+
+</html>


### PR DESCRIPTION
## 概要
-  を追加
- 2.6系アプリ向けに、個人情報を収集しない方針を明記
- 端末内に保存する設定・プレイ記録・解禁状態と、外部リンクの扱いを記載

## 方針
既存の  は旧アプリから参照される可能性があるため変更しない。2.6系のリリース時にアプリ側リンクを新ページへ向ける想定。

新URL想定:


## 確認
- 既存ページは未変更
- 追加HTMLの内容を目視確認

## 備考
push時にGitHubから既存依存関係の脆弱性通知が出ているが、このPRの変更対象外。