### PR TITLE
arisute プライバシーポリシー 2.6 に英訳埋め込み(URLクエリ ?lang=en で切替)

### DIFF
--- a/arisute/privacy-policy-2.6.html
+++ b/arisute/privacy-policy-2.6.html
@@ -18,58 +18,87 @@
 
 		<div class="board boardtext left board-banner">
             <div class="boardmargin">
-				<p class="space"><b>■プライバシーポリシー</b></p>
+				<p class="space"><b data-ja="■プライバシーポリシー" data-en="■Privacy Policy">■プライバシーポリシー</b></p>
 				<div>
-					<p>
+					<p data-ja="ありすのステージ 2.6系（以下「本アプリ」）は、利用者の個人情報を収集しません。"
+					   data-en="Arisu's Stage 2.6 series (hereinafter &quot;the App&quot;) does not collect personal information from its users.">
 						ありすのステージ 2.6系（以下「本アプリ」）は、利用者の個人情報を収集しません。
 					</p>
 				</div>
 				<div class="paragraph">
-					<p class="space"><b>■取得する情報について</b></p>
-					<p>
+					<p class="space"><b data-ja="■取得する情報について" data-en="■Information Collected">■取得する情報について</b></p>
+					<p data-ja="本アプリは、氏名、メールアドレス、位置情報、端末識別子、広告ID、連絡先、写真、その他利用者を識別できる情報を取得・収集しません。&lt;br /&gt;また、広告配信、アクセス解析、行動追跡を目的としたSDKは使用していません。"
+					   data-en="The App does not collect or store any name, email address, location data, device identifier, advertising ID, contacts, photos, or other information that can identify the user.&lt;br /&gt;The App also does not use SDKs intended for advertising delivery, access analytics, or behavioral tracking.">
 						本アプリは、氏名、メールアドレス、位置情報、端末識別子、広告ID、連絡先、写真、その他利用者を識別できる情報を取得・収集しません。<br />
 						また、広告配信、アクセス解析、行動追跡を目的としたSDKは使用していません。
 					</p>
 
-					<p class="space"><b>■端末内に保存される情報</b></p>
-					<p>
+					<p class="space"><b data-ja="■端末内に保存される情報" data-en="■Information Stored on the Device">■端末内に保存される情報</b></p>
+					<p data-ja="本アプリは、ゲームの進行や設定を維持するため、以下の情報を利用者の端末内に保存します。"
+					   data-en="The App stores the following information on the user's device in order to retain game progress and settings.">
 						本アプリは、ゲームの進行や設定を維持するため、以下の情報を利用者の端末内に保存します。
 					</p>
 					<ul>
-						<li>音量、言語、表示などの設定</li>
-						<li>スコア、ランク、クリア回数などのプレイ記録</li>
-						<li>解禁状態などのゲーム進行情報</li>
+						<li data-ja="音量、言語、表示などの設定" data-en="Settings such as volume, language, and display options">音量、言語、表示などの設定</li>
+						<li data-ja="スコア、ランク、クリア回数などのプレイ記録" data-en="Play records such as scores, ranks, and clear counts">スコア、ランク、クリア回数などのプレイ記録</li>
+						<li data-ja="解禁状態などのゲーム進行情報" data-en="Game progress information such as unlock states">解禁状態などのゲーム進行情報</li>
 					</ul>
-					<p>
+					<p data-ja="これらの情報は端末内に保存され、本アプリの開発者へ送信されることはありません。"
+					   data-en="This information is stored on the device and is not transmitted to the App developer.">
 						これらの情報は端末内に保存され、本アプリの開発者へ送信されることはありません。
 					</p>
 
-					<p class="space"><b>■外部リンクについて</b></p>
-					<p>
+					<p class="space"><b data-ja="■外部リンクについて" data-en="■External Links">■外部リンクについて</b></p>
+					<p data-ja="本アプリ内には、クレジット、関連サイト、SNS、プライバシーポリシー等への外部リンクが含まれる場合があります。&lt;br /&gt;外部サイトを開いた後の情報の取り扱いについては、各サイトのプライバシーポリシーをご確認ください。"
+					   data-en="The App may contain external links to credits, related sites, social media, privacy policies, and similar pages.&lt;br /&gt;For the handling of information after opening such external sites, please refer to the privacy policy of each respective site.">
 						本アプリ内には、クレジット、関連サイト、SNS、プライバシーポリシー等への外部リンクが含まれる場合があります。<br />
 						外部サイトを開いた後の情報の取り扱いについては、各サイトのプライバシーポリシーをご確認ください。
 					</p>
 
-					<p class="space"><b>■第三者への提供について</b></p>
-					<p>
+					<p class="space"><b data-ja="■第三者への提供について" data-en="■Provision to Third Parties">■第三者への提供について</b></p>
+					<p data-ja="本アプリは、利用者の個人情報を収集しないため、第三者へ提供することもありません。&lt;br /&gt;ただし、App Store、Google Play、OS、端末、外部サイト等が独自に取得する情報については、本アプリの管理対象外です。"
+					   data-en="Because the App does not collect any personal information from its users, it also does not provide any such information to third parties.&lt;br /&gt;Information independently collected by the App Store, Google Play, the operating system, the device, or any external sites is outside the scope of the App's control.">
 						本アプリは、利用者の個人情報を収集しないため、第三者へ提供することもありません。<br />
 						ただし、App Store、Google Play、OS、端末、外部サイト等が独自に取得する情報については、本アプリの管理対象外です。
 					</p>
 
-					<p class="space"><b>■お問い合わせ</b></p>
-					<p>Twitter <a href="https://twitter.com/fumilin">ふみ(@fumilin)</a> までDMをお願いいたします。</p>
+					<p class="space"><b data-ja="■お問い合わせ" data-en="■Contact">■お問い合わせ</b></p>
+					<p data-ja="Twitter &lt;a href=&quot;https://twitter.com/fumilin&quot;&gt;ふみ(@fumilin)&lt;/a&gt; までDMをお願いいたします。"
+					   data-en="Please send a DM via Twitter to &lt;a href=&quot;https://twitter.com/fumilin&quot;&gt;Fumi (@fumilin)&lt;/a&gt;.">Twitter <a href="https://twitter.com/fumilin">ふみ(@fumilin)</a> までDMをお願いいたします。</p>
 
-					<p class="space"><b>■改定について</b></p>
-					<p>
+					<p class="space"><b data-ja="■改定について" data-en="■Revisions">■改定について</b></p>
+					<p data-ja="本ポリシーの内容は、必要に応じて変更される場合があります。&lt;br /&gt;変更後の内容は、本ページに掲載された時点で有効となります。"
+					   data-en="The content of this policy may be revised as necessary.&lt;br /&gt;Any revised content becomes effective at the time it is posted on this page.">
 						本ポリシーの内容は、必要に応じて変更される場合があります。<br />
 						変更後の内容は、本ページに掲載された時点で有効となります。
 					</p>
 
-					<p class="space">制定日: 2026年6月19日</p>
+					<p class="space" data-ja="制定日: 2026年6月19日" data-en="Effective date: June 19, 2026">制定日: 2026年6月19日</p>
 				</div>
 			</div>
-		</div>	
+		</div>
 	</article>
+	<script>
+		(function () {
+			var params = new URLSearchParams(window.location.search);
+			var lang = (params.get('lang') || '').toLowerCase();
+			// 'en' を渡された時だけ英語に切り替える。デフォルトは日本語(後方互換)。
+			if (lang !== 'en') return;
+
+			document.documentElement.setAttribute('lang', 'en');
+			document.title = "Arisu's Stage - Privacy Policy 2.6";
+
+			var nodes = document.querySelectorAll('[data-en]');
+			for (var i = 0; i < nodes.length; i++) {
+				var node = nodes[i];
+				var enText = node.getAttribute('data-en');
+				if (enText == null) continue;
+				// data-en の値には HTML エンティティ(&lt;br /&gt; など)を入れているので、
+				// そのまま innerHTML へ流して <br> やリンクを復元する。
+				node.innerHTML = enText;
+			}
+		})();
+	</script>
 </body>
 
 </html>


### PR DESCRIPTION
## 概要

「2.6 系プライバシーポリシーに英語追加」。アプリ側から言語情報を URL クエリで渡して表示を切り替える方式にした。

## 変更内容

- `arisute/privacy-policy-2.6.html` を単一 HTML のまま、各テキスト要素に `data-ja` / `data-en` 属性を追加
- 末尾の `<script>` で `?lang=en` クエリを読み、英訳に置換(デフォルトは日本語のまま=後方互換)
- `<br />`・リンク等の HTML マークアップは `data-en` 内に HTML エンティティで保持し、`innerHTML` で復元
- `<title>` と `<html lang>` も英語側で書き換え

## アプリ側

別 PR(`arisute` リポジトリ)で `CreditController` から言語に応じて `?lang=en` を付けて開くように変更する。

## ファイル分割しなかった理由

- 「アプリから言語情報を URL に渡してアクセスする感じ」に最も素直に一致する
- 旧アプリ(クエリなし)も同じ URL でそのまま日本語表示できる(後方互換)
- 将来 ja/en 以外を増やす場合も `data-xx` を増やすだけ

## 確認

- ローカルで `privacy-policy-2.6.html?lang=en` をブラウザで開いて英訳の置換を確認
- `privacy-policy-2.6.html` (クエリなし)はそのまま日本語
