### PR TITLE
train-go: PWA更新時のHTTP cacheを回避

### DIFF
--- a/train-go/README.md
+++ b/train-go/README.md
@@ -27,7 +27,7 @@
 
 - ビルドなしの素の HTML / CSS / JS。canvas 描画
 - 音声: Web Speech API (読み上げ) + WebAudio (警笛・チャイム)。外部素材なし
-- PWA: manifest + service worker (https 配信時のみ登録、オフライン可)
+- PWA: manifest + service worker (https または localhost で登録、オフライン可)
 - アイコン生成: `python make_icons.py` (要 Pillow)
 
 ## 動作確認 (ローカル)
@@ -48,3 +48,5 @@ https なので service worker が有効になり、ホーム画面に追加す�
 
 - タブ/アプリが非表示の間は 200ms 間隔の低頻度更新に落ちる(電池対策と検証容易性の折衷)
 - 読み上げの声質は端末の Web Speech API に依存する
+- オンライン時は HTTP cache を避けて最新版を取得し、取得成功時にオフライン用Cache Storageを更新する
+- 新しい service worker が有効になった時は一度だけ自動リロードする

--- a/train-go/app.js
+++ b/train-go/app.js
@@ -715,7 +715,20 @@
   }
 
   // ---- PWA ----
-  if ("serviceWorker" in navigator && location.protocol === "https:") {
-    navigator.serviceWorker.register("sw.js").catch(() => {});
+  const canUseServiceWorker = location.protocol === "https:"
+    || location.hostname === "localhost"
+    || location.hostname === "127.0.0.1";
+  if ("serviceWorker" in navigator && canUseServiceWorker) {
+    let reloadingForServiceWorker = false;
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+      if (reloadingForServiceWorker) return;
+      reloadingForServiceWorker = true;
+      location.reload();
+    });
+
+    navigator.serviceWorker
+      .register("sw.js", { updateViaCache: "none" })
+      .then((registration) => registration.update())
+      .catch(() => {});
   }
 })();

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,5 +1,5 @@
-// オフラインでも遊べるようにするだけの最小 service worker。
-const CACHE = "train-go-v4";
+// オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
+const CACHE = "train-go-v5";
 const ASSETS = [
   ".",
   "index.html",
@@ -10,9 +10,18 @@ const ASSETS = [
   "icons/icon-512.png",
 ];
 
+async function precacheFreshAssets() {
+  const cache = await caches.open(CACHE);
+  await Promise.all(ASSETS.map(async (asset) => {
+    const request = new Request(asset, { cache: "reload" });
+    const response = await fetch(request);
+    if (!response.ok) throw new Error(`Failed to precache ${asset}: ${response.status}`);
+    await cache.put(asset, response);
+  }));
+}
+
 self.addEventListener("install", (e) => {
-  e.waitUntil(caches.open(CACHE).then((c) => c.addAll(ASSETS)));
-  self.skipWaiting();
+  e.waitUntil(Promise.all([precacheFreshAssets(), self.skipWaiting()]));
 });
 
 self.addEventListener("activate", (e) => {
@@ -24,8 +33,30 @@ self.addEventListener("activate", (e) => {
   self.clients.claim();
 });
 
+async function fetchFreshOrCached(request) {
+  try {
+    // Safari の HTTP cache を使わず、配信元から最新版を取得する。
+    const response = await fetch(new Request(request, { cache: "reload" }));
+    if (response.ok) {
+      const cache = await caches.open(CACHE);
+      await cache.put(request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+
+    // URL に query が付いていても、オフライン時はアプリ本体を開けるようにする。
+    if (request.mode === "navigate") {
+      const appShell = await caches.match("index.html");
+      if (appShell) return appShell;
+    }
+    throw error;
+  }
+}
+
 self.addEventListener("fetch", (e) => {
-  e.respondWith(
-    caches.match(e.request).then((hit) => hit || fetch(e.request))
-  );
+  const url = new URL(e.request.url);
+  if (e.request.method !== "GET" || url.origin !== self.location.origin) return;
+  e.respondWith(fetchFreshOrCached(e.request));
 });


### PR DESCRIPTION
## 変更内容

- service workerをcache-firstからnetwork-firstへ変更
- オンライン取得で `cache: "reload"` を指定し、SafariのHTTP cacheを回避
- 取得成功時にオフライン用Cache Storageを更新
- 通信失敗時は保存済みアセットへフォールバック
- service worker登録に `updateViaCache: "none"` と明示的な `registration.update()` を追加
- 新しいworkerへ切り替わった時に一度だけ自動リロード
- localhostでもservice workerを登録し、更新・オフライン動作を検証可能に変更

## 目的・原因

iPadのホーム画面PWAでは、旧service workerのcache-first応答により、リロードしても古い `app.js` や `style.css` が表示され続けることがあった。オンライン時に最新版を優先し、オフライン時だけCache Storageを使うことで、更新の確実性とオフライン動作を両立する。

## 影響

- オンライン起動時は毎回配信元から最新版を取得
- 通信できない場合は従来どおりオフライン起動可能
- 新しいservice workerの有効化時に一度だけ画面が再読み込みされる

## 検証

- `node --check train-go/app.js`
- `node --check train-go/sw.js`
- `git diff --check -- train-go`
- ローカルブラウザでオンライン再読み込みを確認
- ローカルHTTP server停止後も選択画面が起動することを確認
- ブラウザconsoleにerror・warningがないことを確認
