### PR TITLE
train-go: バージョン表示と車両追加を修正

### DIFF
--- a/train-go/README.md
+++ b/train-go/README.md
@@ -42,6 +42,7 @@
 - ビルドなしの素の HTML / CSS / JS。canvas 描画
 - 音声: Web Speech API (読み上げ) + WebAudio (警笛・チャイム)。外部素材なし
 - PWA: manifest + service worker (https または localhost で登録、オフライン可)
+- 車両選択画面の下に、反映確認用のバージョンと更新日時を表示。更新時は index.html と sw.js のバージョンを揃える
 - アイコン生成: `python make_icons.py` (要 Pillow)
 
 ## 動作確認 (ローカル)

--- a/train-go/app.js
+++ b/train-go/app.js
@@ -731,7 +731,7 @@
     ensureAudio();
     addCar(trainKey);
   });
-  document.querySelectorAll(".btn-quick-add").forEach((btn) => {
+  document.querySelectorAll(".btn-quick-add:not(#btn-couple)").forEach((btn) => {
     btn.addEventListener("click", () => {
       ensureAudio();
       addCar(btn.dataset.car);

--- a/train-go/index.html
+++ b/train-go/index.html
@@ -53,6 +53,10 @@
       <span>はやぶさ</span>
     </button>
   </div>
+  <!-- 更新時は sw.js の CACHE バージョンと揃える -->
+  <div id="app-version" aria-label="バージョン14、2026年7月18日15時18分更新">
+    <strong>v14</strong><span>2026.07.18 15:18 更新</span>
+  </div>
 </div>
 
 <!-- 走行画面の操作ボタン -->

--- a/train-go/style.css
+++ b/train-go/style.css
@@ -85,6 +85,27 @@ html, body {
   color: #444;
 }
 
+#app-version {
+  position: absolute;
+  left: 50%;
+  bottom: max(2vmin, env(safe-area-inset-bottom));
+  display: flex;
+  align-items: baseline;
+  gap: 1.2vmin;
+  transform: translateX(-50%);
+  padding: 0.8vmin 1.8vmin;
+  border-radius: 999px;
+  color: #45637b;
+  background: rgba(255, 255, 255, 0.72);
+  font-size: clamp(12px, 2.1vmin, 18px);
+  white-space: nowrap;
+}
+
+#app-version strong {
+  color: #2a5caa;
+  font-size: 1.15em;
+}
+
 /* --- 走行画面 UI --- */
 #run-ui {
   position: fixed;

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,5 +1,5 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v13";
+const CACHE = "train-go-v14";
 const ASSETS = [
   ".",
   "index.html",


### PR DESCRIPTION
## 変更内容

- 車両選択画面の下部にv14と更新日時を表示
- 表示番号とService Worker cacheをv14へ統一
- 選択中車両ボタンの二重listener登録を解消
- バージョン更新手順をREADMEへ追記

## 目的

iPadで再読み込みした内容が最新版か目で確認できるようにします。また、選択中の車両を追加すると1タップで2両増えていた不具合を修正します。

## 原因

選択中の車両追加ボタンが専用listenerに加えて共通の.btn-quick-add listenerにも登録され、1回のタップでaddCarが2回呼ばれていました。

## 検証

- node --check train-go/app.js
- node --check train-go/sw.js
- git diff --check
- トップ画面にv14 / 2026.07.18 15:18 更新が収まること
- 選択中車両を1回押すと1両から2両、もう1回で3両になること
- console errorなし