### PR TITLE
train-go: 雨の向きと踏切表示を修正

### DIFF
--- a/train-go/app.js
+++ b/train-go/app.js
@@ -1139,7 +1139,7 @@
 
   function drawCrossing() {
     if (routeEvent !== "crossing" || !routeEventAnnounced) return;
-    const x = W * (1.02 - (routeEventProgress - 0.22) * 1.5);
+    const x = W * 0.76;
     const { x0, x1 } = viewRange();
     if (x < x0 - 160 || x > x1 + 160) return;
     const nearY = H * GROUND_R;
@@ -1182,8 +1182,9 @@
     if (weather === "rain") {
       ctx.strokeStyle = "rgba(205,235,255,0.72)";
       ctx.lineWidth = 2;
+      const rainSpan = W + 80;
       for (let i = 0; i < 85; i++) {
-        const x = (i * 79 + weatherTime * 310) % (W + 80) - 40;
+        const x = ((i * 79 - weatherTime * 310) % rainSpan + rainSpan) % rainSpan - 40;
         const y = (i * 47 + weatherTime * 520) % (H + 50) - 25;
         ctx.beginPath(); ctx.moveTo(x, y); ctx.lineTo(x - 12, y + 25); ctx.stroke();
       }

--- a/train-go/index.html
+++ b/train-go/index.html
@@ -54,8 +54,8 @@
     </button>
   </div>
   <!-- 更新時は sw.js の CACHE バージョンと揃える -->
-  <div id="app-version" aria-label="バージョン15、2026年7月18日16時04分更新">
-    <strong>v15</strong><span>2026.07.18 16:04 更新</span>
+  <div id="app-version" aria-label="バージョン16、2026年7月18日16時37分更新">
+    <strong>v16</strong><span>2026.07.18 16:37 更新</span>
   </div>
 </div>
 

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,5 +1,5 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v15";
+const CACHE = "train-go-v16";
 const ASSETS = [
   ".",
   "index.html",


### PR DESCRIPTION
## 変更内容
- 雨粒の水平移動を右向きから左向きへ修正し、線の傾きどおり左下へ流れるように変更
- 踏切をイベント進捗でスクロールさせず、画面右側の固定位置に表示
- 表示バージョンとService Worker cacheをv16へ更新

## 原因
雨粒の描画線は左下向きでしたが、毎フレームのx座標が正方向へ増えていたため、動きとしては右下へ流れていました。踏切は区間進捗をx座標へ変換していたため、実駅間距離では短時間で画面外へ移動していました。

## 検証
- `node --check train-go/app.js`
- `node --check train-go/sw.js`
- `git diff --check -- train-go`
- ローカルブラウザの連続画像で雨粒が左下へ移動することを確認
- 走行中も踏切が同じ画面位置に残ることを確認
- ブラウザのconsole errorなし