### PR TITLE
train-go: タイトルをバージョン表示横へ移す

### DIFF
--- a/train-go/index.html
+++ b/train-go/index.html
@@ -16,7 +16,6 @@
 
 <!-- 車両えらび画面 -->
 <div id="select-screen">
-  <h1 class="game-title">つなげて！でんしゃ！</h1>
   <div class="select-title">どこを はしる？</div>
   <div class="route-buttons" role="group" aria-label="はしるろせん">
     <button class="route-btn selected" data-route="chuo" aria-pressed="true"><span>🟧</span>ちゅうおうせん</button>
@@ -89,8 +88,9 @@
     </button>
   </div>
   <!-- 更新時は sw.js の CACHE バージョンと揃える -->
-  <div id="app-version" aria-label="バージョン30、2026年7月19日11時22分更新">
-    <strong>v30</strong><span>2026.07.19 11:22 更新</span>
+  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン31、2026年7月19日11時35分更新">
+    <span class="version-title">つなげて！でんしゃ！</span>
+    <strong>v31</strong><span>2026.07.19 11:35 更新</span>
   </div>
 </div>
 

--- a/train-go/style.css
+++ b/train-go/style.css
@@ -43,15 +43,6 @@ html, body {
   z-index: 10;
 }
 
-.game-title {
-  color: #174f9a;
-  font-size: clamp(24px, 4.6vmin, 46px);
-  font-weight: 900;
-  letter-spacing: 0.08em;
-  line-height: 1;
-  text-shadow: 0 0.35vmin 0 #fff;
-}
-
 .select-title {
   font-size: 5.5vmin;
   font-weight: bold;
@@ -137,8 +128,8 @@ html, body {
 #app-version {
   position: static;
   display: flex;
-  align-items: baseline;
-  gap: 1.2vmin;
+  align-items: center;
+  gap: 1vmin;
   transform: none;
   padding: 0.8vmin 1.8vmin;
   border-radius: 999px;
@@ -153,6 +144,12 @@ html, body {
   font-size: 1.15em;
 }
 
+.version-title {
+  padding-right: 1.2vmin;
+  border-right: 1px solid rgba(69, 99, 123, 0.28);
+  color: #36516a;
+  font-weight: 800;
+}
 
 @media (min-aspect-ratio: 4/3) {
   #select-screen { gap: 1.3vmin; padding-top: max(1.5vmin, env(safe-area-inset-top)); }

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,5 +1,5 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v30";
+const CACHE = "train-go-v31";
 const ASSETS = [
   ".",
   "index.html",


### PR DESCRIPTION
## 変更内容

- 選択画面上部の大きなタイトルを削除
- 「つなげて！でんしゃ！」を下部のバージョン表示左側へ小さく配置
- タイトルとバージョン情報の間に控えめな区切りを追加
- 表示とService Workerキャッシュをv31へ更新

## 目的

タイトルを常に確認できる状態は保ちつつ、路線・車両選択に使える縦方向の余白を増やします。

## 検証

- `node --check train-go/app.js`
- `node --check train-go/sw.js`
- `manifest.webmanifest` のJSON解析
- `git diff --check`
- 1024×768のブラウザDOMでタイトル・v31・更新日時が一列に並ぶこととアクセシブル名を確認

画面キャプチャはブラウザ接続のタイムアウトにより未取得です。