### PR TITLE
train-go: OGPと作者リンクを追加

### DIFF
--- a/train-go/README.md
+++ b/train-go/README.md
@@ -55,6 +55,7 @@
 - 音声: Web Speech API (読み上げ) + WebAudio (警笛・チャイム)。外部素材なし
 - PWA: manifest + service worker (https または localhost で登録、オフライン可)
 - 車両選択画面の下に、反映確認用のバージョンと更新日時を表示。更新時は index.html と sw.js のバージョンを揃える
+- Xなどで共有した時にタイトル・説明・アイコンを表示するOGPと、作者・感想・不具合の連絡先リンクを車両選択画面に表示する
 - アイコン生成: `python make_icons.py` (要 Pillow)
 
 ## 動作確認 (ローカル)

--- a/train-go/index.html
+++ b/train-go/index.html
@@ -6,6 +6,21 @@
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="apple-mobile-web-app-title" content="つなげて！でんしゃ！">
+<meta name="description" content="好きな電車をつなげて、実際の駅や景色を走ろう。小さな子どもから遊べる、でんしゃ連結ゲーム。">
+<meta property="og:type" content="website">
+<meta property="og:title" content="つなげて！でんしゃ！">
+<meta property="og:description" content="好きな電車をつなげて、実際の駅や景色を走ろう。小さな子どもから遊べる、でんしゃ連結ゲーム。">
+<meta property="og:url" content="https://ethfumi.github.io/web/train-go/">
+<meta property="og:image" content="https://ethfumi.github.io/web/train-go/icons/icon-512.png">
+<meta property="og:image:width" content="512">
+<meta property="og:image:height" content="512">
+<meta property="og:image:alt" content="つなげて！でんしゃ！の電車アイコン">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:creator" content="@fumilin">
+<meta name="twitter:title" content="つなげて！でんしゃ！">
+<meta name="twitter:description" content="好きな電車をつなげて、実際の駅や景色を走ろう。小さな子どもから遊べる、でんしゃ連結ゲーム。">
+<meta name="twitter:image" content="https://ethfumi.github.io/web/train-go/icons/icon-512.png">
+<meta name="twitter:image:alt" content="つなげて！でんしゃ！の電車アイコン">
 <title>つなげて！でんしゃ！</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="apple-touch-icon" href="icons/icon-180.png">
@@ -93,10 +108,14 @@
     </button>
   </div>
   <!-- 更新時は sw.js の CACHE バージョンと揃える -->
-  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン38、2026年7月19日16時28分更新">
+  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン39、2026年7月19日16時52分更新">
     <span class="version-title">つなげて！でんしゃ！</span>
-    <strong>v38</strong><span>2026.07.19 16:28 更新</span>
+    <strong>v39</strong><span>2026.07.19 16:52 更新</span>
   </div>
+  <a id="creator-contact" href="https://x.com/fumilin" target="_blank" rel="noopener noreferrer">
+    <span>つくったひと：ふみ（@fumilin）</span>
+    <span>ごかんそう・ふぐあいはこちら</span>
+  </a>
 </div>
 
 <!-- 走行画面の操作ボタン -->

--- a/train-go/style.css
+++ b/train-go/style.css
@@ -151,6 +151,30 @@ html, body {
   font-weight: 800;
 }
 
+#creator-contact {
+  display: flex;
+  align-items: center;
+  gap: 1.2vmin;
+  padding: 0.7vmin 1.6vmin;
+  border-radius: 999px;
+  color: #45637b;
+  background: rgba(255, 255, 255, 0.58);
+  font-size: clamp(11px, 1.8vmin, 16px);
+  text-decoration: none;
+}
+
+#creator-contact span + span {
+  padding-left: 1.2vmin;
+  border-left: 1px solid rgba(69, 99, 123, 0.28);
+  color: #2a5caa;
+  font-weight: 700;
+}
+
+#creator-contact:focus-visible {
+  outline: 3px solid #2a5caa;
+  outline-offset: 2px;
+}
+
 @media (min-aspect-ratio: 4/3) {
   #select-screen { gap: 1.3vmin; padding-top: max(1.5vmin, env(safe-area-inset-top)); }
   .train-buttons {
@@ -166,6 +190,8 @@ html, body {
 
 @media (max-width: 560px) {
   .route-buttons { grid-template-columns: repeat(2, 1fr); }
+  #creator-contact { flex-direction: column; gap: 0.2vmin; border-radius: 3vmin; }
+  #creator-contact span + span { padding-left: 0; border-left: 0; }
 }
 
 #select-screen:not(.hidden) ~ .debug-control {

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,5 +1,5 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v38";
+const CACHE = "train-go-v39";
 const ASSETS = [
   ".",
   "index.html",


### PR DESCRIPTION
## 変更内容

- Open Graphのタイトル・説明・URL・画像・代替テキストを追加
- X Cardのタイトル・説明・画像・作者アカウントを追加
- 車両選択画面の末尾に、作者と感想・不具合の連絡先を追加
- スマートフォンでは連絡先を二段表示
- 表示とService Workerキャッシュをv39へ更新

## 背景

公開URLをXなどへ投稿した時に内容が分かるカード情報がなく、作者・問い合わせ先も画面上から確認できなかった。既存の電車アイコンを共有画像として再利用し、遊びを邪魔しない選択画面の最下部へ連絡先を置いた。

## 確認

- `node --check train-go/app.js`
- `node --check train-go/sw.js`
- `manifest.webmanifest` JSON parse
- `git diff --check`
- 通常画面と390×844縦画面で作者リンクの表示・非重複を確認
- OGP/X用メタタグの値をブラウザ上で確認
- `https://x.com/fumilin`、`target=_blank`、`rel=noopener noreferrer`を確認
- console error 0件