### PR TITLE
train-go: 折り返し時に編成の向きを反転する

### DIFF
--- a/train-go/app.js
+++ b/train-go/app.js
@@ -2058,6 +2058,10 @@
   }
   const NOSE_R = 0.62;   // 先頭車の画面上の位置(画面幅比)
 
+  function trainFacesLeft() {
+    return !activeRoute.loopKm && routeDirection < 0;
+  }
+
   function carMetrics() {
     const carW = Math.min(W * 0.22, 190);
     return { carW, carH: carW * 0.32, gap: 8 };
@@ -2815,7 +2819,15 @@
     ctx.font = `bold ${Math.max(14, radius * 1.25)}px sans-serif`;
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
+    ctx.save();
+    if (trainFacesLeft()) {
+      // 編成全体の反転中も、車両番号だけは読みやすい向きを保つ。
+      ctx.translate(x, 0);
+      ctx.scale(-1, 1);
+      ctx.translate(-x, 0);
+    }
     ctx.fillText(String(number), x, y + 1);
+    ctx.restore();
     ctx.textBaseline = "alphabetic";
   }
 
@@ -3191,6 +3203,7 @@
     canvas.dataset.cars = String(totalCarCount());
     canvas.dataset.platformWidth = String(Math.round(stationPlatformWidth(nextStationName)));
     canvas.dataset.trainStationOffset = String(Math.round(trainStationOffset()));
+    canvas.dataset.trainFacing = trainFacesLeft() ? "left" : "right";
     canvas.dataset.stationScreenX = String(Math.round(stationScreenX(stationWorldX, nextStationName)));
     canvas.dataset.fallingStarX = fallingStar ? String(Math.round(fallingStar.x)) : "";
     canvas.dataset.fallingStarY = fallingStar ? String(Math.round(fallingStar.y)) : "";
@@ -3217,10 +3230,18 @@
       drawDistanceMarkers();
       drawInspectionEffect();
       drawStations();
+      if (trainFacesLeft()) {
+        // 外側のカメラ拡縮後も画面中央を軸に見えるよう、座標系側の反転軸を補正する。
+        const mirrorCenterX = ax + (W * 0.5 - ax) / Math.max(viewScale, 0.001);
+        ctx.save();
+        ctx.translate(mirrorCenterX * 2, 0);
+        ctx.scale(-1, 1);
+      }
       drawHeadlight();
       drawTrainMotionEffects();
       drawTrain();
       drawKomachi();
+      if (trainFacesLeft()) ctx.restore();
       ctx.restore();
     }
     drawWeather(dt);

--- a/train-go/index.html
+++ b/train-go/index.html
@@ -24,7 +24,7 @@
 <title>つなげて！でんしゃ！</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="apple-touch-icon" href="icons/icon-180.png">
-<link rel="stylesheet" href="style.css?v=48">
+<link rel="stylesheet" href="style.css?v=49">
 </head>
 <body>
 <canvas id="game"></canvas>
@@ -124,9 +124,9 @@
     </div>
   </div>
   <!-- 更新時は sw.js の CACHE バージョンと揃える -->
-  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン48、2026年7月19日20時35分更新">
+  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン49、2026年7月19日22時41分更新">
     <span class="version-title">つなげて！でんしゃ！</span>
-    <strong>v48</strong><span>2026.07.19 20:35 更新</span>
+    <strong>v49</strong><span>2026.07.19 22:41 更新</span>
   </div>
   <a id="creator-contact" href="https://x.com/fumilin" target="_blank" rel="noopener noreferrer">
     <span>3歳の息子のために作りました。</span>
@@ -216,6 +216,6 @@
   <span>🔦</span><span id="headlight-label">ライトをつける</span>
 </button>
 
-<script src="app.js?v=48"></script>
+<script src="app.js?v=49"></script>
 </body>
 </html>

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,10 +1,10 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v48";
+const CACHE = "train-go-v49";
 const ASSETS = [
   ".",
   "index.html",
-  "style.css?v=48",
-  "app.js?v=48",
+  "style.css?v=49",
+  "app.js?v=49",
   "manifest.webmanifest",
   "icons/icon-180.png",
   "icons/icon-512.png",


### PR DESCRIPTION
## 変更内容
- 非環状路線の折り返し後、編成を復路方向の左向きへ反転
- ライトと加減速エフェクトも進行方向に合わせて反転
- 長編成のズームを考慮し、画面中央を基準に配置
- 車両番号は鏡文字にせず読みやすい向きを維持
- 山手線は環状運転なので従来の向きを維持
- v49へ更新

## 確認
- \
ode --check train-go/app.js\`n- \
ode --check train-go/sw.js\`n- \git diff --check\`n- ブラウザで往路が右向き、復路が左向きになること
- ブラウザで16両の復路編成が画面に収まり、車両番号を正しく読めること