### PR TITLE
mandelbulb: 作者リンクを修正

### DIFF
--- a/mandelbulb/index.html
+++ b/mandelbulb/index.html
@@ -71,7 +71,7 @@
     <button id="openPanel" class="dockButton" aria-label="フラクタルと数式メニューを開く"><b>⌁</b><small>LIBRARY</small></button>
     <button id="reset" class="dockButton" aria-label="視点をリセット"><b>↺</b><small>RESET</small></button>
   </nav>
-  <footer class="credits"><span>FRACTAL FIELD v1.1.0</span><a href="https://x.com/paji_a" target="_blank" rel="me noopener noreferrer">BY @PAJI_A ↗</a></footer>
+  <footer class="credits"><span>FRACTAL FIELD v1.1.0</span><a href="https://x.com/fumilin" target="_blank" rel="me noopener noreferrer">BY @FUMILIN ↗</a></footer>
   <div id="error" class="error" hidden><b>WEBGL2 NOT AVAILABLE</b><p>最新のSafariまたはChromeで開いてください。</p></div>
 </main>
 <script src="./app.js"></script>


### PR DESCRIPTION
## 概要

フラクタルビューアーの作者Xリンクを正しいアカウントへ修正します。

## 変更内容

- リンク先を `https://x.com/paji_a` から `https://x.com/fumilin` へ変更
- 表示名を `@PAJI_A` から `@FUMILIN` へ変更

## 検証

- 差分が `mandelbulb/index.html` の1行だけであることを確認
- `git diff --check`