### PR TITLE
mandelbulb: v1.1アセットのキャッシュを更新

### DIFF
--- a/mandelbulb/index.html
+++ b/mandelbulb/index.html
@@ -7,10 +7,10 @@
   <meta name="description" content="ズームするほど咲き続けるリアルタイム無限カレイドスコープ">
   <meta property="og:title" content="INFINITE ROSETTE / SCALE BLOOM">
   <meta property="og:description" content="拡大そのものが模様になるリアルタイム無限ズーム・カレイドスコープ">
-  <meta property="og:image" content="./og.png">
+  <meta property="og:image" content="./og.png?v=1.1">
   <meta name="twitter:card" content="summary_large_image">
   <title>INFINITE ROSETTE / SCALE BLOOM</title>
-  <link rel="stylesheet" href="./style.css">
+  <link rel="stylesheet" href="./style.css?v=1.1">
 </head>
 <body>
 <main class="app">
@@ -81,6 +81,6 @@
   </nav>
   <div id="error" class="error" hidden><b>WEBGL2 NOT AVAILABLE</b><p>最新のSafariまたはChromeで開いてください。</p></div>
 </main>
-<script src="./app.js"></script>
+<script src="./app.js?v=1.1"></script>
 </body>
 </html>


### PR DESCRIPTION
## 変更内容

- `app.js`・`style.css`・`og.png`へ`v1.1`のキャッシュキーを追加

## 理由

PR #76のPages公開後、HTMLとメニューは更新された一方で旧`app.js`がブラウザキャッシュから読み込まれ、初期表示がMengerになる状態を実ブラウザで確認しました。リリース版とアセットURLを揃え、新しい無限ズーム表示を確実に取得させます。

## 検証

- `node --check mandelbulb/app.js`
- `git diff --check origin/master...HEAD`
- ローカル配信で`INFINITE ROSETTE`が初期選択され、`LIVE RENDER`になることを確認
