### PR TITLE
web: Pages配信待ちを公開フローから外す

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository instructions
+
+## GitHub Pages publication
+
+For projects in this repository, complete the required local validation before merging the pull request.
+Treat the publication task as complete when the pull request has been merged.
+
+Do not wait for the GitHub Pages deployment job and do not check the deployed URL as part of the normal publication flow.
+Deployment proceeds asynchronously after the merge, so waiting for delivery is not needed to establish that the requested work is complete.
+
+Only check the Pages deployment or deployed URL when the user explicitly asks for it, or when investigating behavior that can only be reproduced in the deployed environment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# Repository instructions
+
+## GitHub Pages publication
+
+For projects in this repository, complete the required local validation before merging the pull request.
+Treat the publication task as complete when the pull request has been merged.
+
+Do not wait for the GitHub Pages deployment job and do not check the deployed URL as part of the normal publication flow.
+Deployment proceeds asynchronously after the merge, so waiting for delivery is not needed to establish that the requested work is complete.
+
+Only check the Pages deployment or deployed URL when the user explicitly asks for it, or when investigating behavior that can only be reproduced in the deployed environment.


### PR DESCRIPTION
## 変更内容
- Codex向けのAGENTS.mdを追加
- Claude向けのCLAUDE.mdを追加
- 両方に同一のGitHub Pages公開完了条件を記載

## 公開完了条件
- 必要なローカル検証はmerge前に実施
- PRがmergeされた時点で公開作業を完了
- 通常はPages deploymentの完了待ちと配信URL確認を行わない
- 明示依頼または配信環境固有の調査時のみ確認

## 理由
merge後のPages配信は非同期で進むため、依頼された作業の完了判定に配信待ちは必要ありません。

## 確認
- AGENTS.mdとCLAUDE.mdが同一内容であることを確認
- git diff --check
- 公開情報チェック