### PR TITLE
train-go: 非公式アプリの注意書きを削除

### DIFF
--- a/train-go/index.html
+++ b/train-go/index.html
@@ -115,11 +115,10 @@
     </div>
   </div>
   <!-- 更新時は sw.js の CACHE バージョンと揃える -->
-  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン60、2026年7月21日9時34分更新">
+  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン61、2026年7月21日9時40分更新">
     <span class="version-title">つなげて！でんしゃ！</span>
-    <strong>v60</strong><span>2026.07.21 09:34 更新</span>
+    <strong>v61</strong><span>2026.07.21 09:40 更新</span>
   </div>
-  <div id="unofficial-note">各鉄道会社の公式・公認アプリではありません。</div>
   <a id="creator-contact" href="https://x.com/fumilin" target="_blank" rel="noopener noreferrer">
     <span>3歳の息子のために作りました。</span>
     <span>ごかんそう・あいであはこちら → X @fumilin（ふみ）</span>
@@ -209,7 +208,7 @@
   <span>🔦</span><span id="headlight-label">ライトをつける</span>
 </button>
 
-<script src="app.js?v=60"></script>
+<script src="app.js?v=61"></script>
 <!-- Cloudflare Web Analytics: Cookieを使用せず、個人を識別しないアクセス集計 -->
 <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"ca5e1fbb318447b3ac9409f3da1cad2a"}'></script>
 </body>

--- a/train-go/style.css
+++ b/train-go/style.css
@@ -185,11 +185,6 @@ html, body {
   outline-offset: 2px;
 }
 
-#unofficial-note {
-  color: #60798c;
-  font-size: clamp(10px, 1.6vmin, 14px);
-}
-
 @media (min-aspect-ratio: 4/3) {
   #select-screen { gap: 1.3vmin; padding-top: max(1.5vmin, env(safe-area-inset-top)); }
   .train-buttons {

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,5 +1,5 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v60";
+const CACHE = "train-go-v61";
 const ASSETS = [
   ".",
   "index.html",


### PR DESCRIPTION
## 変更
- 『各鉄道会社の公式・公認アプリではありません。』を削除
- 不要になった専用CSSを削除
- v61へ更新

## 確認
- 
ode --check train-go/app.js
- 
ode --check train-go/sw.js
- git diff --check
- 実画面で注意書きが存在しないことを確認
- Cloudflare Web Analyticsのタグが残っていることを確認
- ブラウザwarning/error 0件