### PR TITLE
train-goに簡潔な更新履歴を追加

### DIFF
--- a/train-go/index.html
+++ b/train-go/index.html
@@ -25,7 +25,7 @@
 <title>つなげて！でんしゃ！</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="apple-touch-icon" href="icons/icon-180.png">
-<link rel="stylesheet" href="style.css?v=59">
+<link rel="stylesheet" href="style.css?v=63">
 </head>
 <body>
 <canvas id="game"></canvas>
@@ -114,10 +114,21 @@
       </button>
     </div>
   </div>
-  <!-- 更新時は sw.js の CACHE バージョンと揃える -->
-  <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン62、2026年7月22日7時39分更新">
-    <span class="version-title">つなげて！でんしゃ！</span>
-    <strong>v62</strong><span>2026.07.22 07:39 更新</span>
+  <div id="release-info">
+    <!-- 更新時は sw.js の CACHE バージョンと揃える -->
+    <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン63、2026年7月22日8時11分更新">
+      <span class="version-title">つなげて！でんしゃ！</span>
+      <strong>v63</strong><span>2026.07.22 08:11 更新</span>
+    </div>
+    <details id="update-history">
+      <summary>🆕 こうしん</summary>
+      <div class="update-history-list" aria-label="こうしんりれき">
+        <span><time datetime="2026-07-22">7/22</time> やまのてせんの ちずを ついか</span>
+        <span><time datetime="2026-07-21">7/21</time> 100りょうでも なめらかに</span>
+        <span><time datetime="2026-07-20">7/20</time> おきゃくさんで かそくアップ</span>
+        <span><time datetime="2026-07-19">7/19</time> しゅうてんから おりかえし</span>
+      </div>
+    </details>
   </div>
   <a id="creator-contact" href="https://x.com/fumilin" target="_blank" rel="noopener noreferrer">
     <span>3歳の息子のために作りました。</span>
@@ -209,7 +220,7 @@
   <span>🔦</span><span id="headlight-label">ライトをつける</span>
 </button>
 
-<script src="app.js?v=62"></script>
+<script src="app.js?v=63"></script>
 <!-- Cloudflare Web Analytics: Cookieを使用せず、個人を識別しないアクセス集計 -->
 <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"ca5e1fbb318447b3ac9409f3da1cad2a"}'></script>
 </body>

--- a/train-go/style.css
+++ b/train-go/style.css
@@ -135,6 +135,14 @@ html, body {
 }
 
 
+#release-info {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1vmin;
+  flex-wrap: wrap;
+}
+
 #app-version {
   position: static;
   display: flex;
@@ -152,6 +160,59 @@ html, body {
 #app-version strong {
   color: #2a5caa;
   font-size: 1.15em;
+}
+
+#update-history {
+  position: relative;
+  z-index: 5;
+  color: #45637b;
+  font-size: clamp(12px, 2.1vmin, 18px);
+}
+
+#update-history summary {
+  padding: 0.8vmin 1.5vmin;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+  font-weight: 800;
+  list-style: none;
+  white-space: nowrap;
+}
+
+#update-history summary::-webkit-details-marker {
+  display: none;
+}
+
+#update-history summary:focus-visible {
+  outline: 3px solid #2a5caa;
+  outline-offset: 2px;
+}
+
+.update-history-list {
+  position: absolute;
+  left: 50%;
+  right: auto;
+  transform: translateX(-50%);
+  bottom: calc(100% + 1vmin);
+  display: grid;
+  gap: 0.55em;
+  width: max-content;
+  max-width: min(84vw, 420px);
+  padding: 1em 1.2em;
+  border: 2px solid rgba(69, 99, 123, 0.16);
+  border-radius: 1.2em;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 0.6em 1.5em rgba(45, 76, 96, 0.2);
+  color: #36516a;
+  text-align: left;
+  line-height: 1.35;
+}
+
+.update-history-list time {
+  display: inline-block;
+  min-width: 3.4em;
+  color: #2a5caa;
+  font-weight: 800;
 }
 
 .version-title {

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,10 +1,10 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v62";
+const CACHE = "train-go-v63";
 const ASSETS = [
   ".",
   "index.html",
-  "style.css?v=59",
-  "app.js?v=59",
+  "style.css?v=63",
+  "app.js?v=63",
   "manifest.webmanifest",
   "icons/icon-180.png",
   "icons/icon-512.png",


### PR DESCRIPTION
## 変更内容
- バージョン表示の横に小さな「🆕 こうしん」ボタンを追加
- 開いた時だけ、直近4件の日付と主な追加内容を表示
- スマホ縦画面でも履歴が画面外へはみ出さない中央配置
- Service Workerと静的アセット参照をv63へ更新

## 検証
- `node --check train-go/app.js`
- `node --check train-go/sw.js`
- `git diff --check`
- ローカルブラウザでPC表示と390×844の縦画面を確認
- 更新履歴の開閉、画面内への収まり、ブラウザエラーなしを確認