### PR TITLE
train-goの地図駅名を読みやすく配置

### DIFF
--- a/train-go/app.js
+++ b/train-go/app.js
@@ -2628,7 +2628,7 @@
     const stationList = [{ name: activeRoute.start, km: activeRoute.startKm }, ...activeRoute.stations.slice(0, -1)];
     while (routeStationMapPositions.length < stationList.length) routeStationMapPositions.push({});
     ctx.font = "bold " + labelSize + "px sans-serif";
-    ctx.textBaseline = "middle";
+    ctx.textBaseline = "bottom";
     for (let index = 0; index < stationList.length; index++) {
       const station = stationList[index];
       const position = yamanoteMapPositionAt(station.km, routeStationMapPositions[index], map);
@@ -2646,10 +2646,9 @@
       ctx.fill();
       ctx.stroke();
       if (!showLabel) continue;
-      const leftHalf = index < stationList.length / 2;
       ctx.fillStyle = timeOfDay === "night" ? "#f4f7fb" : "#344054";
-      ctx.textAlign = leftHalf ? "right" : "left";
-      ctx.fillText(station.name, x + (leftHalf ? -labelSize * 0.75 : labelSize * 0.75), y);
+      ctx.textAlign = "center";
+      ctx.fillText(station.name, x, y - labelSize * 0.55);
     }
     ctx.restore();
   }

--- a/train-go/index.html
+++ b/train-go/index.html
@@ -25,7 +25,7 @@
 <title>つなげて！でんしゃ！</title>
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="apple-touch-icon" href="icons/icon-180.png">
-<link rel="stylesheet" href="style.css?v=69">
+<link rel="stylesheet" href="style.css?v=70">
 </head>
 <body>
 <canvas id="game"></canvas>
@@ -116,13 +116,14 @@
   </div>
   <div id="release-info">
     <!-- 更新時は sw.js の CACHE バージョンと揃える -->
-    <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン69、2026年7月22日22時00分更新">
+    <div id="app-version" aria-label="つなげて！でんしゃ！、バージョン70、2026年7月22日22時06分更新">
       <span class="version-title">つなげて！でんしゃ！</span>
-      <strong>v69</strong><span>2026.07.22 22:00 更新</span>
+      <strong>v70</strong><span>2026.07.22 22:06 更新</span>
     </div>
     <details id="update-history">
       <summary>🆕 こうしん</summary>
       <div class="update-history-list" aria-label="こうしんりれき">
+        <span><time datetime="2026-07-22">7/22</time> ちずの えきめいを よみやすく</span>
         <span><time datetime="2026-07-22">7/22</time> きちじょうじの のりかえをしゅうせい</span>
         <span><time datetime="2026-07-22">7/22</time> にほんのかたちと ちずUIをしゅうせい</span>
         <span><time datetime="2026-07-22">7/22</time> ちずを すっきり・かそくパワー</span>
@@ -225,8 +226,8 @@
   <span>🔦</span><span id="headlight-label">ライトをつける</span>
 </button>
 
-<script src="map-data.js?v=69"></script>
-<script src="app.js?v=69"></script>
+<script src="map-data.js?v=70"></script>
+<script src="app.js?v=70"></script>
 <!-- Cloudflare Web Analytics: Cookieを使用せず、個人を識別しないアクセス集計 -->
 <script type="module" src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token":"ca5e1fbb318447b3ac9409f3da1cad2a"}'></script>
 </body>

--- a/train-go/sw.js
+++ b/train-go/sw.js
@@ -1,11 +1,11 @@
 // オンラインでは常に最新版を取得し、通信できない時だけ保存済みデータを使う。
-const CACHE = "train-go-v69";
+const CACHE = "train-go-v70";
 const ASSETS = [
   ".",
   "index.html",
-  "style.css?v=69",
-  "map-data.js?v=69",
-  "app.js?v=69",
+  "style.css?v=70",
+  "map-data.js?v=70",
+  "app.js?v=70",
   "manifest.webmanifest",
   "icons/icon-180.png",
   "icons/icon-512.png",


### PR DESCRIPTION
## 変更内容
- 上から・全体地図の駅名を駅丸の少し上へ移動
- 駅名を中央揃えにして、路線が斜めでも文字は水平に表示
- バージョンと更新履歴をv70へ更新

## 検証
- node --check train-go/app.js
- node --check train-go/map-data.js
- node --check train-go/sw.js
- git diff --check
- ローカルブラウザの総武線「うえから」で三鷹・吉祥寺の駅名が線路から離れて表示されることを確認
- console error / warning 0件